### PR TITLE
:construction: feat(Proxy): Initial code for proxying requests from gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/go.sum
+/.idea

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"errors"
+	"github.com/spf13/cobra"
+	"kinto-cli-go/pkg/kintohub"
+	"strings"
+)
+
+var ProxyCmd = &cobra.Command{
+	Use:     "proxy",
+	Example: "proxy {block-name}:{port}",
+	Short:   "Proxy a specific kintoblock's traffic a local port",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 {
+			splitStr := strings.Split(args[0], ":")
+			if len(splitStr) != 2 {
+				return errors.New("Invalid proxy argument. Must provide argument {block-name}:{port}")
+			}
+		} else {
+			return errors.New("Did not provide a proxy target and destination {block-name}:${port}")
+		}
+
+		return nil
+	},
+	Run: HandleProxyAction,
+}
+
+func HandleProxyAction(cmd *cobra.Command, args []string) {
+	splitStr := strings.Split(args[0], ":")
+	blockName := splitStr[0]
+	forwardPort := splitStr[1]
+
+	api := kintohub.InitApi("token")
+	api.CreateProxy("api.kintohub.com", blockName, forwardPort)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"os"
+)
+
+var cfgFile string
+
+func init() {
+	//cobra.OnInitialize(initConfig)
+
+	rootCmd.AddCommand(ProxyCmd)
+
+	//rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kinto.yaml)")
+	rootCmd.PersistentFlags().StringP("gateway", "g", "gateway", "kinto-gateway hostname")
+	viper.BindPFlag("gateway", rootCmd.PersistentFlags().Lookup("gateway"))
+	viper.SetDefault("gateway", "api.kintohub.com")
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "kinto",
+	Short: "Kinto cli tools allow you to quickly debug and interact with KintoHub",
+}
+
+func initConfig() {
+	// Don't forget to read config either from cfgFile or from home directory!
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Search config in home directory with name ".cobra" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".kinto")
+	}
+
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Println("Can't read config:", err)
+		os.Exit(1)
+	} else {
+		//TODO: Create default config
+	}
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module kinto-cli-go
+
+require (
+	github.com/fasthttp/websocket v1.4.0
+	github.com/magiconair/properties v1.8.0
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/spf13/cobra v0.0.3
+	github.com/spf13/viper v1.3.2
+	github.com/valyala/fasthttp v1.2.0
+)

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"kinto-cli-go/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/kintohub/api.go
+++ b/pkg/kintohub/api.go
@@ -1,0 +1,15 @@
+package kintohub
+
+type Api struct {
+	authToken string
+}
+
+func InitApi(authToken string) Api {
+	return Api{
+		authToken: authToken,
+	}
+}
+
+func (a *Api) CreateProxy(gatewayHost string, blockName string, forwardPort string) {
+	createWebsocketProxy(gatewayHost, a.authToken, blockName, forwardPort)
+}

--- a/pkg/kintohub/websocket.go
+++ b/pkg/kintohub/websocket.go
@@ -1,0 +1,105 @@
+package kintohub
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/fasthttp/websocket"
+	"github.com/valyala/fasthttp"
+	"log"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+)
+
+type ProxyRequestMessage struct {
+	RequestId string            `json:"requestId"`
+	Method    string            `json:"method"`
+	Uri       string            `json:"uri"`
+	Headers   map[string][]byte `json:"headers"`
+	Data      []byte            `json:"data"`
+}
+
+type ProxyResponseMessage struct {
+	RequestId string            `json:"requestId"`
+	Headers   map[string][]byte `json:"headers"`
+	Data      []byte            `json:"data"`
+}
+
+func createWebsocketProxy(gatewayHostname string, authToken string, blockName string, portToForward string) {
+	proxyClient := fasthttp.HostClient{
+		Addr: "localhost:" + portToForward,
+	}
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+
+	path := fmt.Sprintf("/proxy?authToken=%v&blockName=%v",
+		authToken,
+		blockName)
+
+	u := url.URL{Scheme: "ws", Host: gatewayHostname, Path: path}
+
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+
+	if err != nil {
+		log.Fatal("Failed to create proxy:", err)
+	}
+
+	defer c.Close()
+	done := make(chan struct{})
+	defer close(done)
+
+	for {
+		proxyMsg := ProxyRequestMessage{}
+		err := c.ReadJSON(&proxyMsg)
+
+		if err != nil {
+			if strings.Contains(err.Error(), "websocket: close") {
+				log.Print("Websocket has been closed!")
+			} else {
+				log.Println("Error occurred reading proxy msg", err)
+			}
+			return
+		}
+
+		prettyReqBytes, _ := json.MarshalIndent(proxyMsg, "", "\t")
+		log.Printf(">> Proxying Request to localhost:%v: %v", portToForward, string(prettyReqBytes))
+		response := proxyMessage(proxyClient, proxyMsg)
+		prettyRespBytes, _ := json.MarshalIndent(response, "", "\t")
+		log.Printf("<< Proxying Response to %v: %v", u.String(), string(prettyRespBytes))
+		c.WriteJSON(response)
+	}
+}
+
+func proxyMessage(client fasthttp.HostClient, msg ProxyRequestMessage) ProxyResponseMessage {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+
+	req.Header.SetHost(client.Addr)
+	req.Header.SetMethod(msg.Method)
+	req.SetRequestURI(msg.Uri)
+	msgBytes, err := json.Marshal(msg)
+	req.SetBody(msgBytes)
+
+	err = client.Do(req, resp)
+
+	if err != nil {
+		log.Fatal("Error proxying request to client", err)
+	}
+
+	response := ProxyResponseMessage{
+		RequestId: msg.RequestId,
+		Data:      resp.Body(),
+		Headers:   map[string][]byte{},
+	}
+
+	resp.Header.VisitAll(func(key, value []byte) {
+		response.Headers[string(key)] = value
+	})
+
+	fasthttp.ReleaseRequest(req)
+	fasthttp.ReleaseResponse(resp)
+
+	return response
+}

--- a/pkg/kintohub/websocket_test.go
+++ b/pkg/kintohub/websocket_test.go
@@ -1,0 +1,87 @@
+package kintohub
+
+import (
+	"encoding/json"
+	"github.com/fasthttp/websocket"
+	"github.com/magiconair/properties/assert"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+var upgrader = websocket.Upgrader{} // use default options
+
+func TestWebsocket(t *testing.T) {
+
+	testContainer := TestContainer{
+		T: t,
+	}
+
+	gatewayServer := httptest.NewServer(http.HandlerFunc(testContainer.gatewayHandler))
+	proxyServer := httptest.NewServer(http.HandlerFunc(testContainer.proxyHandler))
+
+	defer gatewayServer.Close()
+	defer proxyServer.Close()
+
+	createWebsocketProxy(strings.TrimPrefix(gatewayServer.URL, "http://"),
+		"abcd1234", "auth", strings.Split(proxyServer.URL, ":")[2])
+}
+
+type TestContainer struct {
+	T *testing.T
+}
+
+func (c *TestContainer) gatewayHandler(w http.ResponseWriter, r *http.Request) {
+	con, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Print("upgrade:", err)
+		return
+	}
+	defer con.Close()
+
+	//TODO: Check request URI
+
+	reqMsg := ProxyRequestMessage{
+		RequestId: "1",
+		Method:    http.MethodPost,
+		Data:      []byte("test-message"),
+	}
+
+	err = con.WriteJSON(reqMsg)
+
+	if err != nil {
+		c.T.Fatal("Error sending proxy message", err)
+	}
+
+	resp := ProxyResponseMessage{}
+	err = con.ReadJSON(&resp)
+
+	if err != nil {
+		c.T.Fatal("Could not read response json", err)
+	}
+
+	assert.Equal(c.T, resp.Data, reqMsg.Data)
+	assert.Equal(c.T, resp.RequestId, reqMsg.RequestId)
+}
+
+func (c *TestContainer) proxyHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+
+	defer r.Body.Close()
+
+	if err != nil {
+		c.T.Fatal("Proxied Service could not read message", err)
+	}
+
+	msg := ProxyRequestMessage{}
+	err = json.Unmarshal(b, &msg)
+
+	if err != nil {
+		c.T.Fatal("Proxied service cannot parse json message", err)
+	}
+
+	w.Write(msg.Data)
+}


### PR DESCRIPTION
* Basic commands with go's CLI tool cobra
* kinto proxy {block-name}:{local-port} created
* Websocket tests to create websocket connection and forward requests to local service is complete! (92.7%) - Missing header forward tests + fail tests.